### PR TITLE
Improved handling of single quotes in macro params

### DIFF
--- a/src/XacroParser.js
+++ b/src/XacroParser.js
@@ -214,7 +214,7 @@ export class XacroParser {
                 }
 
                 obj.name = name;
-                obj.def = def;
+                obj.def = def.replace(/'/g, '');
             } else {
                 obj.name = param;
                 obj.def = null;

--- a/src/XacroParser.js
+++ b/src/XacroParser.js
@@ -234,7 +234,7 @@ export class XacroParser {
             if (params) {
                 const inputs = params
                     .trim()
-                    .split(/\s+/g)
+                    .split(/ +(?=[\w]+\:)/g)
                     .map(s => parseMacroParam(s));
                 inputs.forEach(inp => {
                     inputMap[inp.name] = inp;


### PR DESCRIPTION
Some robot models, e.g. the [Franka Emika](https://github.com/frankaemika/franka_ros/blob/kinetic-devel/franka_description/robots/panda_arm.xacro) one, use strings with sequences of numbers as vectors (e.g. '0 0 1'). These will be erroneously split into several params where the name is null, causing the parser to fail. 

In addition, the above mentioned model uses an empty string for some of its default parameters, signified by two single quotes (''). This is usually fine, however, it needs special handling in `xacro:if` and `xacro:unless` statements, as the resulting javascript string will not be empty ("''"). Keeping the single quotes also made package resolution more difficult, so I decided to remove them entirely. This will cause `utils.isString` to always return false, but it's rarely used and doesn't seem to create any issues so far.