### PR TITLE
support for vectors in macro defines (ie: "name:='a b c'")

### DIFF
--- a/src/XacroParser.js
+++ b/src/XacroParser.js
@@ -214,7 +214,10 @@ export class XacroParser {
                 }
 
                 obj.name = name;
-                obj.def = def;
+                if(def.startsWith('\'') && def.endsWith('\''))
+                    obj.def = def.substr(1,def.length-2);
+                else
+                    obj.def = def;
             } else {
                 obj.name = param;
                 obj.def = null;
@@ -234,7 +237,7 @@ export class XacroParser {
             if (params) {
                 const inputs = params
                     .trim()
-                    .split(/\s+/g)
+                    .match(/[^\s']+(['][^']*['])?/g)
                     .map(s => parseMacroParam(s));
                 inputs.forEach(inp => {
                     inputMap[inp.name] = inp;

--- a/umd/index.js
+++ b/umd/index.js
@@ -2214,7 +2214,10 @@
                     }
 
                     obj.name = name;
-                    obj.def = def;
+                    if(def.startsWith('\'') && def.endsWith('\''))
+                        obj.def = def.substr(1,def.length-2);
+                    else
+                        obj.def = def;
                 } else {
                     obj.name = param;
                     obj.def = null;
@@ -2234,7 +2237,7 @@
                 if (params) {
                     const inputs = params
                         .trim()
-                        .split(/\s+/g)
+                        .match(/[^\s']+(['][^']*['])?/g)
                         .map(s => parseMacroParam(s));
                     inputs.forEach(inp => {
                         inputMap[inp.name] = inp;


### PR DESCRIPTION
Same problems as the other pull request (did not notice it before I made these changes). Other solution...
Experienced the same problem while loading Franka-Emika specs.