### PR TITLE
Add support for `$(arg)`, `<xacro:arg>` tags, and input arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,12 @@ arguments = {} : Object
 A map of argument names to values that will be substituted for `$(arg name)` tags. These take precedence over any `<xacro:arg>` defaults.
 
 ```js
-loader.arguments = { arg_name: 'arg_value' };
+loader.arguments =
+  {
+    transmission_hw_interface: "hardware_interface/PositionJointInterface",
+    arm_x_separation: -0.4,
+    laser_visual: true,
+  };
 ```
 
 ### .rospackCommands

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ parser.workingPath = './path/to/directory/';
 parser.getFileContents = path => {
 
   return fs.readFile( path, { encoding: 'utf8' } );
-  
+
 };
 
 const xacroContents = fs.readFileSync( './path/to/directory/file.xacro', { encoding: 'utf8' } );
@@ -54,14 +54,14 @@ fetch( './path/to/directory/file.xacro' )
     parser.getFileContents = path => {
 
       return fetch( path ).then( res => res.text() );
-  
+
     };
     parser.parse( xacroContents ).then( result => {
 
       // xacro XML
 
     } );
-    
+
 } );
 
 ```
@@ -147,6 +147,18 @@ workingPath = '' : string
 ```
 
 The working directory to search for dependent files in when parsing `include` tags. The path is required to end with '/'.
+
+### .arguments
+
+```js
+arguments = {} : Object
+```
+
+A map of argument names to values that will be substituted for `$(arg name)` tags. These take precedence over any `<xacro:arg>` defaults.
+
+```js
+loader.arguments = { arg_name: 'arg_value' };
+```
 
 ### .rospackCommands
 

--- a/src/XacroLoader.d.ts
+++ b/src/XacroLoader.d.ts
@@ -1,6 +1,7 @@
 interface XacroLoaderOptions {
 
     rospackCommands?: { [key: string]: (...args:string[]) => string },
+    arguments?: { [key: string]: string | number | boolean },
     localProperties?: boolean,
     inOrder?: boolean,
     fetchOptions?: object,

--- a/src/XacroParser.d.ts
+++ b/src/XacroParser.d.ts
@@ -1,6 +1,7 @@
 export class XacroParser {
 
     rospackCommands?: { [key: string]: (...args:string[]) => string } | ((command: string, ...args: string[]) => string);
+    arguments?: { [key: string]: string | number | boolean };
     localProperties?: boolean;
     inOrder?: boolean;
     workingPath?: string;

--- a/src/XacroParser.js
+++ b/src/XacroParser.js
@@ -22,7 +22,6 @@ export class XacroParser {
         this.localProperties = true;
         this.rospackCommands = {};
         this.arguments = {};
-        this.argumentDefaults = {};
         this.workingPath = '';
     }
 
@@ -410,7 +409,7 @@ export class XacroParser {
                 }
                 case 'xacro:arg': {
                     const name = node.getAttribute('name');
-                    scope.argumentDefaults[name] = evaluateAttribute(node.getAttribute('default'), properties, true);
+                    argumentDefaults[name] = evaluateAttribute(node.getAttribute('default'), properties, true);
                     return;
                 }
                 case 'xacro:attribute':
@@ -530,6 +529,7 @@ export class XacroParser {
         const rospackCommands = this.rospackCommands;
         const globalMacros = {};
         const includeMap = {};
+        const argumentDefaults = {};
         const globalProperties = { True: 1, False: 0 };
         globalProperties[PARENT_SCOPE] = globalProperties;
 
@@ -552,7 +552,7 @@ export class XacroParser {
                 }
                 result = this.arguments[arg];
                 if (result == null) {
-                    result = this.argumentDefaults[arg];
+                    result = argumentDefaults[arg];
                 }
                 if (result == null) {
                     throw new Error(`XacroParser: Undefined substitution argument ${ arg }`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -60,9 +60,9 @@ export function isString(str) {
     return regexp.test(str);
 }
 
-// TODO: make this more robust
+// https://stackoverflow.com/a/175787
 export function isNumber(str) {
-    return !isNaN(parseFloat(str)) && !/[^0-9.eE-]/.test(str);
+    return !isNaN(Number(str)) && !isNaN(parseFloat(str));
 }
 
 // TODO: this needs to tokenize numbers together

--- a/test/XacroLoader.test.js
+++ b/test/XacroLoader.test.js
@@ -31,6 +31,12 @@ const files = {
             <inlined-c/>
         </robot>
     `,
+    './d.xacro':
+        `<?xml version="1.0"?>
+        <robot xmlns:xacro="http://ros.org/wiki/xacro">
+            <child d="$(arg d)"/>
+        </robot>
+    `,
 
 };
 
@@ -861,6 +867,55 @@ describe('XacroLoader', () => {
         });
         it.todo('should support absolute paths.');
         it.todo('should respect namespaces for macros and properties.');
+    });
+
+    describe('arg', () => {
+        it('should make provided args accessible to imported files.', done => {
+            const content =
+                `<?xml version="1.0"?>
+                <robot xmlns:xacro="http://ros.org/wiki/xacro">
+                    <xacro:include filename="./d.xacro"/>
+                </robot>
+            `;
+
+            const loader = new XacroLoader();
+            loader.arguments = {d: 'd-val'};
+            loader.parse(
+                content, res => {
+                    const str = new XMLSerializer().serializeToString(res);
+                    expect(unformat(str)).toEqual(unformat(
+                        `<robot>
+                            <child d="d-val"/>
+                        </robot>`,
+                    ));
+                    done();
+                },
+            );
+
+        });
+        it('should make xacro:arg defaults accessible to imported files.', done => {
+            const content =
+                `<?xml version="1.0"?>
+                <robot xmlns:xacro="http://ros.org/wiki/xacro">
+                    <xacro:arg name="d" default="d-val"/>
+                    <xacro:include filename="./d.xacro"/>
+                </robot>
+            `;
+
+            const loader = new XacroLoader();
+            loader.parse(
+                content, res => {
+                    const str = new XMLSerializer().serializeToString(res);
+                    expect(unformat(str)).toEqual(unformat(
+                        `<robot>
+                            <child d="d-val"/>
+                        </robot>`,
+                    ));
+                    done();
+                },
+            );
+
+        });
     });
 
     describe('options.inOrder', () => {

--- a/test/XacroLoader.test.js
+++ b/test/XacroLoader.test.js
@@ -918,7 +918,6 @@ describe('XacroLoader', () => {
             loader.parse(
                 content, res => {
                     const str = new XMLSerializer().serializeToString(res);
-                    console.log(str);
                     expect(unformat(str)).toEqual(unformat(
                         `<robot>
                             <child a="rospack-a" b="b-val"/>
@@ -951,7 +950,6 @@ describe('XacroLoader', () => {
             loader.parse(
                 content, res => {
                     const str = new XMLSerializer().serializeToString(res);
-                    console.log(str);
                     expect(unformat(str)).toEqual(unformat(
                         `<robot>
                             <child a="rospack-a" b="b-val"/>


### PR DESCRIPTION
- Resolves https://github.com/gkjohnson/xacro-parser/issues/3
- Fixes a bug with `isNumber()` that was revealed by importing some more tests from https://github.com/ros/xacro — `isNumber('0.5-0.3')` was returning true! 😬 

Open to feedback on the use of `scope.arguments`, wasn't sure if that was the best way to do it!

I also tried to leave the `$(arg)` handling as a fallback so user-provided rospackCommands will be used first. However, I think if the user provided a _function_ for rospackCommands, then this fallback would not be used. Feel free to suggest any improvements you'd like to make here.