### PR TITLE
expose constant tau

### DIFF
--- a/src/ExpressionParser.js
+++ b/src/ExpressionParser.js
@@ -67,6 +67,7 @@ export class ExpressionParser extends Parser {
         parser.consts = {
             ...parser.consts,
             pi: Math.PI,
+            tau: 2 * Math.PI,
             e: Math.E,
         };
     }


### PR DESCRIPTION
Thank you for your work on this library @gkjohnson !

xacro officially exposes Python's `math.tau` (along with all other math symbols).
My attempt to use https://github.com/MorningFrog/urdf-visualizer just failed because xacro-parser was missing the constant.

https://github.com/ros/xacro/blob/d3265d04a991b4ad8b645022f06326b6fa7b9df3/src/xacro/__init__.py#L219